### PR TITLE
Updating getStdDevs()

### DIFF
--- a/util/VisionFunctions.java
+++ b/util/VisionFunctions.java
@@ -27,23 +27,23 @@ public class VisionFunctions {
     public static Matrix<N3, N1> getStdDevs(PhotonCamera camera, Pose2d estimatedPose, PhotonPoseEstimator poseEstimator) {
         List<PhotonTrackedTarget> targets = camera.getAllUnreadResults().get(0).getTargets();
         int numTags = 0;
-        double avgDist = 0;
+        double dist = 0;
         for (PhotonTrackedTarget target : targets) {
             Optional<Pose3d> tagPose = poseEstimator.getFieldTags().getTagPose(target.fiducialId);
             if (tagPose.isEmpty()) continue;
 
             numTags++;
-            avgDist += tagPose.get().toPose2d().getTranslation().getDistance(estimatedPose.getTranslation());
+
+            // Looks weird, but this is only used when there is one tag, so it doesn't need to be averaged.
+            dist = tagPose.get().toPose2d().getTranslation().getDistance(estimatedPose.getTranslation());
         }
 
         if (numTags == 0) return VisionConstants.singleTagStdDevs;
 
         if (numTags > 1) return VisionConstants.multiTagStdDevs;
 
-        avgDist /= numTags;
+        if (dist > 4) return VecBuilder.fill(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
 
-        if (numTags == 1 && avgDist > 4) return VecBuilder.fill(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
-
-        return VisionConstants.singleTagStdDevs.times(1 + (avgDist * avgDist / 30));
+        return VisionConstants.singleTagStdDevs.times(1 + (dist * dist / 30));
     }
 }


### PR DESCRIPTION
- **Allowing VisionResults to be serialized for logging**
- **Formatting VisionResult.java and removing unused imports.  'timestamp' is one word**
- **Formatting VisionResultStruct.java**
- **Adjusting constants**
- **Formatting and making the IO a parameter**
- **Removing unused or relatively unused variables/functions**
- **formatting, logging null, and removing the 'Active' value (its always true)**
- **Moving logged values**
- **Adding a loggable VisionIOInputs class**
- **Updating IO getUnreadResults functions and formatting**
- **Updating VisionFunctions.java**
- **Optimizing getStdDevs()**
